### PR TITLE
feat: 🎸 Add isBuiltInCallable, add type-guard overloads and refactor helpers to function declarations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ A set of JavaScript helper functions to check for types.
   - [Usage](#usage)
   - [API](#api)
     - [isBoolean()](#isboolean)
+    - [isBuiltInCallable()](#isbuiltincallable)
     - [isBuiltInConstructor()](#isbuiltinconstructor)
     - [isClass()](#isclass)
+    - [isDefined()](#isdefined)
     - [isInstanceOfUnknownClass()](#isinstanceofunknownclass)
     - [isNotBoolean()](#isnotboolean)
     - [isNotNumber()](#isnotnumber)
@@ -53,52 +55,144 @@ isString('asd'); // true;
 
 ### isBoolean()
 
+Checks if the given value is a boolean.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isBoolean(variable): boolean;
+function isBoolean(value): value is boolean;
 ```
 
-Defined in: [main.ts:41](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L41)
-
-Checks if the given variable is a boolean.
+Defined in: [main.ts:85](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L85)
 
 **Parameters**
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is boolean`
+
+**Call Signature**
+
+```ts
+function isBoolean(value): boolean;
+```
+
+Defined in: [main.ts:90](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L90)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
 **Returns**
 
 `boolean`
 
-True if the variable is a boolean, false otherwise.
+---
+
+### isBuiltInCallable()
+
+Checks if a given value is a **built-in JavaScript callable**.
+
+A built-in callable is either:
+
+- a standard **constructor** (e.g., `Object`, `Array`, `Date`, `Map`), or
+- a callable **non-constructable** built-in (`BigInt`, `Symbol`).
+
+This function first verifies the value is a function, then tests identity
+against a curated set of built-ins.
+
+Overloads:
+
+- **Predicate:** narrows the value to `BuiltInCallable` on success.
+- **Boolean:** usable in contexts that require a plain `(v) => boolean`.
+
+**Param**
+
+The value to check.
+
+**Example**
+
+```ts
+isBuiltInCallable(Object); // true
+isBuiltInCallable(Array); // true
+isBuiltInCallable(BigInt); // true (callable but not a constructor)
+isBuiltInCallable(Symbol); // true (callable but not a constructor)
+isBuiltInCallable(class X {}); // false
+isBuiltInCallable(() => {}); // false
+isBuiltInCallable(123); // false
+
+// Type narrowing:
+declare const fn: unknown;
+if (isBuiltInCallable(fn)) {
+  // fn is now typed as BuiltInCallable
+  console.log(fn.name);
+}
+```
+
+#### See
+
+- <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects>
+- <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/BigInt>
+- <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/Symbol>
+
+**Call Signature**
+
+```ts
+function isBuiltInCallable(value): value is BuiltInCallable;
+```
+
+Defined in: [main.ts:539](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L539)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is BuiltInCallable`
+
+**Call Signature**
+
+```ts
+function isBuiltInCallable(value): boolean;
+```
+
+Defined in: [main.ts:544](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L544)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
 
 ---
 
 ### isBuiltInConstructor()
-
-```ts
-function isBuiltInConstructor(value): boolean;
-```
-
-Defined in: [main.ts:273](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L273)
 
 Checks if a given value is a built-in JavaScript constructor.
 
 This function verifies whether the provided value is a function and matches
 one of JavaScript's built-in constructors, such as `Object`, `Array`, `Function`, etc.
 
-**Parameters**
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
-
-**Returns**
-
-`boolean`
-
-`true` if the value is a built-in constructor, otherwise `false`.
+The value to check.
 
 **Example**
 
@@ -110,15 +204,45 @@ console.log(isBuiltInConstructor(() => {})); // Output: false
 console.log(isBuiltInConstructor(123)); // Output: false
 ```
 
+**Call Signature**
+
+```ts
+function isBuiltInConstructor(value): value is BuiltInConstructor;
+```
+
+Defined in: [main.ts:439](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L439)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is BuiltInConstructor`
+
+**Call Signature**
+
+```ts
+function isBuiltInConstructor(value): boolean;
+```
+
+Defined in: [main.ts:446](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L446)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
 ---
 
 ### isClass()
-
-```ts
-function isClass(value): boolean;
-```
-
-Defined in: [main.ts:240](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L240)
 
 Checks if a given value is a class constructor.
 
@@ -128,17 +252,9 @@ always have a non-writeable prototype, while regular functions do not.
 
 Will always return false on built in constructors like `Date` or `Array`.
 
-**Parameters**
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
-
-**Returns**
-
-`boolean`
-
-`true` if the value is a class constructor, otherwise `false`.
+The value to check.
 
 **Example**
 
@@ -153,15 +269,97 @@ console.log(isClass(() => {})); // Output: false
 console.log(isClass(null)); // Output: false
 ```
 
+**Call Signature**
+
+```ts
+function isClass(value): value is ClassCtor<any>;
+```
+
+Defined in: [main.ts:364](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L364)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is ClassCtor<any>`
+
+**Call Signature**
+
+```ts
+function isClass(value): boolean;
+```
+
+Defined in: [main.ts:369](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L369)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
+---
+
+### isDefined()
+
+Copy of `isNotUndefined`
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
+```ts
+function isDefined<T>(value): value is Exclude<T, undefined>;
+```
+
+Defined in: [main.ts:165](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L165)
+
+**Type Parameters**
+
+| Type Parameter |
+| -------------- |
+| `T`            |
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, undefined>`
+
+**Call Signature**
+
+```ts
+function isDefined(value): boolean;
+```
+
+Defined in: [main.ts:170](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L170)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
 ---
 
 ### isInstanceOfUnknownClass()
-
-```ts
-function isInstanceOfUnknownClass(value): boolean;
-```
-
-Defined in: [main.ts:324](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L324)
 
 Checks if a given value is an instance of a non-standard (unknown) class.
 
@@ -169,17 +367,9 @@ This function determines whether the provided value is an object and has a proto
 that is neither `Object.prototype` (standard object) nor `null` (no prototype).
 It helps differentiate between instances of custom classes and plain objects.
 
-**Parameters**
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
-
-**Returns**
-
-`boolean`
-
-`true` if the value is an instance of a non-standard class, otherwise `false`.
+The value to check.
 
 **Example**
 
@@ -191,152 +381,308 @@ console.log(isInstanceOfUnknownClass(Object.create(null))); // Output: false
 console.log(isInstanceOfUnknownClass([])); // Output: true
 ```
 
----
-
-### isNotBoolean()
+**Call Signature**
 
 ```ts
-function isNotBoolean(variable): boolean;
+function isInstanceOfUnknownClass(value): value is object;
 ```
 
-Defined in: [main.ts:50](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L50)
-
-Checks if the given variable is not a boolean.
+Defined in: [main.ts:595](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L595)
 
 **Parameters**
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is object`
+
+**Call Signature**
+
+```ts
+function isInstanceOfUnknownClass(value): boolean;
+```
+
+Defined in: [main.ts:600](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L600)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
 **Returns**
 
 `boolean`
 
-True if the variable is not a boolean, false otherwise.
+---
+
+### isNotBoolean()
+
+Checks if the given value is not a boolean.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
+```ts
+function isNotBoolean<T>(value): value is Exclude<T, boolean>;
+```
+
+Defined in: [main.ts:105](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L105)
+
+**Type Parameters**
+
+| Type Parameter |
+| -------------- |
+| `T`            |
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, boolean>`
+
+**Call Signature**
+
+```ts
+function isNotBoolean(value): boolean;
+```
+
+Defined in: [main.ts:110](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L110)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
 
 ---
 
 ### isNotNumber()
 
+Checks if the given value is not a number.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNotNumber(variable): boolean;
+function isNotNumber<T>(value): value is Exclude<T, number>;
 ```
 
-Defined in: [main.ts:33](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L33)
+Defined in: [main.ts:65](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L65)
 
-Checks if the given variable is not a number.
+**Type Parameters**
+
+| Type Parameter |
+| -------------- |
+| `T`            |
 
 **Parameters**
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, number>`
+
+**Call Signature**
+
+```ts
+function isNotNumber(value): boolean;
+```
+
+Defined in: [main.ts:70](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L70)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
 **Returns**
 
 `boolean`
-
-True if the variable is not a number, false otherwise.
 
 ---
 
 ### isNotString()
 
+Checks if the given value is not a string.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNotString(variable): boolean;
+function isNotString<T>(value): value is Exclude<T, string>;
 ```
 
-Defined in: [main.ts:16](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L16)
+Defined in: [main.ts:25](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L25)
 
-Checks if the given variable is not a string.
+**Type Parameters**
+
+| Type Parameter |
+| -------------- |
+| `T`            |
 
 **Parameters**
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, string>`
+
+**Call Signature**
+
+```ts
+function isNotString(value): boolean;
+```
+
+Defined in: [main.ts:30](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L30)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
 **Returns**
 
 `boolean`
-
-True if the variable is not a string, false otherwise.
 
 ---
 
 ### isNotUndefined()
 
+Checks if the given value is not undefined.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNotUndefined(variable): boolean;
+function isNotUndefined<T>(value): value is Exclude<T, undefined>;
 ```
 
-Defined in: [main.ts:68](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L68)
+Defined in: [main.ts:145](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L145)
 
-Checks if the given variable is not undefined.
+**Type Parameters**
+
+| Type Parameter |
+| -------------- |
+| `T`            |
 
 **Parameters**
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, undefined>`
+
+**Call Signature**
+
+```ts
+function isNotUndefined(value): boolean;
+```
+
+Defined in: [main.ts:150](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L150)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
 **Returns**
 
 `boolean`
-
-True if the variable is not undefined, false otherwise.
 
 ---
 
 ### isNumber()
 
+Checks if the given value is a number.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNumber(variable): boolean;
+function isNumber(value): value is number;
 ```
 
-Defined in: [main.ts:24](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L24)
-
-Checks if the given variable is a number.
+Defined in: [main.ts:45](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L45)
 
 **Parameters**
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is number`
+
+**Call Signature**
+
+```ts
+function isNumber(value): boolean;
+```
+
+Defined in: [main.ts:50](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L50)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
 **Returns**
 
 `boolean`
 
-True if the variable is a number, false otherwise.
-
 ---
 
 ### isObjectLoose()
-
-```ts
-function isObjectLoose(value): boolean;
-```
-
-Defined in: [main.ts:210](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L210)
 
 Checks if a given value is an object or a function.
 
 This function verifies whether the provided value is of type `'object'` or `'function'`
 while ensuring that `null` is excluded.
 
-**Parameters**
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
-
-**Returns**
-
-`boolean`
-
-`true` if the value is an object or function, otherwise `false`.
+The value to check.
 
 **Example**
 
@@ -378,15 +724,45 @@ console.log(isObjectLoose(42)); // Output: false
 | Recognizes DOM elements                  | ❌ No                            | ✅ Yes                         |
 | Complexity                               | 🔴 High                          | 🟢 Low                         |
 
+**Call Signature**
+
+```ts
+function isObjectLoose(value): value is object;
+```
+
+Defined in: [main.ts:301](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L301)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is object`
+
+**Call Signature**
+
+```ts
+function isObjectLoose(value): boolean;
+```
+
+Defined in: [main.ts:306](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L306)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
 ---
 
 ### isObjectPlain()
-
-```ts
-function isObjectPlain(variable): boolean;
-```
-
-Defined in: [main.ts:104](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L104)
 
 Determines whether a value is a plain object (i.e., created via an object literal,
 `Object.create(null)`, or with `Object` as its prototype).
@@ -394,17 +770,9 @@ Determines whether a value is a plain object (i.e., created via an object litera
 This excludes arrays, functions, class instances, built-ins like `Date`/`Map`/`Set`,
 and other exotic objects.
 
-**Parameters**
+**Param**
 
-| Parameter  | Type      | Description        |
-| ---------- | --------- | ------------------ |
-| `variable` | `unknown` | The value to test. |
-
-**Returns**
-
-`boolean`
-
-`true` if `variable` is a plain object, otherwise `false`.
+The value to test.
 
 **Example**
 
@@ -432,15 +800,45 @@ if (isObjectPlain(value)) {
 - <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/Object/toString>
 - <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/Object/getPrototypeOf>
 
+**Call Signature**
+
+```ts
+function isObjectPlain(value): value is Record<string, unknown>;
+```
+
+Defined in: [main.ts:185](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L185)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is Record<string, unknown>`
+
+**Call Signature**
+
+```ts
+function isObjectPlain(value): boolean;
+```
+
+Defined in: [main.ts:190](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L190)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
 ---
 
 ### isObjectStrict()
-
-```ts
-function isObjectStrict(value): boolean;
-```
-
-Defined in: [main.ts:146](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L146)
 
 Checks if a given value is a plain object.
 
@@ -448,17 +846,9 @@ A plain object is an object created by the `{}` syntax, `Object.create(null)`,
 or using `new Object()`. This function ensures that the value is an object
 and does not have an unusual prototype chain.
 
-**Parameters**
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
-
-**Returns**
-
-`boolean`
-
-`true` if the value is a plain object, otherwise `false`.
+The value to check.
 
 **Example**
 
@@ -487,53 +877,133 @@ console.log(isObjectStrict(null)); // Output: false
 - Use `isObjectStrict` when you need a **strict check for plain objects**.
 - Use `isObjectLoose` if you need to check if a value is an **object-like structure**, including functions.
 
----
-
-### isString()
+**Call Signature**
 
 ```ts
-function isString(variable): boolean;
+function isObjectStrict(value): value is Record<string, unknown>;
 ```
 
-Defined in: [main.ts:7](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L7)
-
-Checks if the given variable is a string.
+Defined in: [main.ts:236](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L236)
 
 **Parameters**
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is Record<string, unknown>`
+
+**Call Signature**
+
+```ts
+function isObjectStrict(value): boolean;
+```
+
+Defined in: [main.ts:243](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L243)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
 **Returns**
 
 `boolean`
 
-True if the variable is a string, false otherwise.
+---
+
+### isString()
+
+Checks if the given value is a string.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
+```ts
+function isString(value): value is string;
+```
+
+Defined in: [main.ts:5](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L5)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is string`
+
+**Call Signature**
+
+```ts
+function isString(value): boolean;
+```
+
+Defined in: [main.ts:10](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L10)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
 
 ---
 
 ### isUndefined()
 
+Checks if the given value is undefined.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isUndefined(variable): boolean;
+function isUndefined(value): value is undefined;
 ```
 
-Defined in: [main.ts:59](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L59)
-
-Checks if the given variable is undefined.
+Defined in: [main.ts:125](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L125)
 
 **Parameters**
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is undefined`
+
+**Call Signature**
+
+```ts
+function isUndefined(value): boolean;
+```
+
+Defined in: [main.ts:130](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L130)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
 **Returns**
 
 `boolean`
-
-True if the variable is undefined, false otherwise.
 
 ---
 

--- a/api/README.md
+++ b/api/README.md
@@ -2,60 +2,200 @@
 
 ---
 
-> Last updated 2025-09-02T07:04:48.996Z
+> Last updated 2025-09-02T10:51:19.888Z
+
+## Type Aliases
+
+### BuiltInCallable
+
+```ts
+type BuiltInCallable = BuiltInConstructor | typeof BigInt | typeof Symbol;
+```
+
+Defined in: [main.ts:501](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L501)
+
+Built-in globals that are **callable**:
+
+- All standard constructors (above)
+- Plus callable, **non-constructable** built-ins: `BigInt` and `Symbol`
+
+---
+
+### BuiltInConstructor
+
+```ts
+type BuiltInConstructor =
+  | ObjectConstructor
+  | ArrayConstructor
+  | FunctionConstructor
+  | StringConstructor
+  | NumberConstructor
+  | BooleanConstructor
+  | DateConstructor
+  | RegExpConstructor
+  | ErrorConstructor
+  | EvalErrorConstructor
+  | RangeErrorConstructor
+  | ReferenceErrorConstructor
+  | SyntaxErrorConstructor
+  | TypeErrorConstructor
+  | URIErrorConstructor
+  | MapConstructor
+  | WeakMapConstructor
+  | SetConstructor
+  | WeakSetConstructor
+  | PromiseConstructor;
+```
+
+Defined in: [main.ts:414](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L414)
+
+A union of standard JavaScript **constructable** built-ins
+(e.g., `Object`, `Array`, `Date`, `Map`, etc.).
 
 ## Functions
 
 ### isBoolean()
 
+Checks if the given value is a boolean.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isBoolean(variable): boolean;
+function isBoolean(value): value is boolean;
 ```
 
-Defined in: [main.ts:41](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L41)
+Defined in: [main.ts:85](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L85)
 
-Checks if the given variable is a boolean.
+**Parameters**
 
-#### Parameters
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+**Returns**
 
-#### Returns
+`value is boolean`
+
+**Call Signature**
+
+```ts
+function isBoolean(value): boolean;
+```
+
+Defined in: [main.ts:90](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L90)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
 
 `boolean`
 
-True if the variable is a boolean, false otherwise.
+---
+
+### isBuiltInCallable()
+
+Checks if a given value is a **built-in JavaScript callable**.
+
+A built-in callable is either:
+
+- a standard **constructor** (e.g., `Object`, `Array`, `Date`, `Map`), or
+- a callable **non-constructable** built-in (`BigInt`, `Symbol`).
+
+This function first verifies the value is a function, then tests identity
+against a curated set of built-ins.
+
+Overloads:
+
+- **Predicate:** narrows the value to `BuiltInCallable` on success.
+- **Boolean:** usable in contexts that require a plain `(v) => boolean`.
+
+**Param**
+
+The value to check.
+
+**Example**
+
+```ts
+isBuiltInCallable(Object); // true
+isBuiltInCallable(Array); // true
+isBuiltInCallable(BigInt); // true (callable but not a constructor)
+isBuiltInCallable(Symbol); // true (callable but not a constructor)
+isBuiltInCallable(class X {}); // false
+isBuiltInCallable(() => {}); // false
+isBuiltInCallable(123); // false
+
+// Type narrowing:
+declare const fn: unknown;
+if (isBuiltInCallable(fn)) {
+  // fn is now typed as BuiltInCallable
+  console.log(fn.name);
+}
+```
+
+#### See
+
+- <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects>
+- <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/BigInt>
+- <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/Symbol>
+
+**Call Signature**
+
+```ts
+function isBuiltInCallable(value): value is BuiltInCallable;
+```
+
+Defined in: [main.ts:539](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L539)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is BuiltInCallable`
+
+**Call Signature**
+
+```ts
+function isBuiltInCallable(value): boolean;
+```
+
+Defined in: [main.ts:544](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L544)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
 
 ---
 
 ### isBuiltInConstructor()
-
-```ts
-function isBuiltInConstructor(value): boolean;
-```
-
-Defined in: [main.ts:273](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L273)
 
 Checks if a given value is a built-in JavaScript constructor.
 
 This function verifies whether the provided value is a function and matches
 one of JavaScript's built-in constructors, such as `Object`, `Array`, `Function`, etc.
 
-#### Parameters
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
+The value to check.
 
-#### Returns
-
-`boolean`
-
-`true` if the value is a built-in constructor, otherwise `false`.
-
-#### Example
+**Example**
 
 ```ts
 console.log(isBuiltInConstructor(Object)); // Output: true
@@ -65,37 +205,59 @@ console.log(isBuiltInConstructor(() => {})); // Output: false
 console.log(isBuiltInConstructor(123)); // Output: false
 ```
 
+**Call Signature**
+
+```ts
+function isBuiltInConstructor(value): value is BuiltInConstructor;
+```
+
+Defined in: [main.ts:439](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L439)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is BuiltInConstructor`
+
+**Call Signature**
+
+```ts
+function isBuiltInConstructor(value): boolean;
+```
+
+Defined in: [main.ts:446](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L446)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
 ---
 
 ### isClass()
-
-```ts
-function isClass(value): boolean;
-```
-
-Defined in: [main.ts:240](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L240)
 
 Checks if a given value is a class constructor.
 
 This function determines whether the provided value is a class by verifying
 if it is a function and checking its prototype descriptor. Class constructors
-always have a non-writable prototype, while regular functions do not.
+always have a non-writeable prototype, while regular functions do not.
 
 Will always return false on built in constructors like `Date` or `Array`.
 
-#### Parameters
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
+The value to check.
 
-#### Returns
-
-`boolean`
-
-`true` if the value is a class constructor, otherwise `false`.
-
-#### Example
+**Example**
 
 ```ts
 class MyClass {}
@@ -108,15 +270,97 @@ console.log(isClass(() => {})); // Output: false
 console.log(isClass(null)); // Output: false
 ```
 
+**Call Signature**
+
+```ts
+function isClass(value): value is ClassCtor<any>;
+```
+
+Defined in: [main.ts:364](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L364)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is ClassCtor<any>`
+
+**Call Signature**
+
+```ts
+function isClass(value): boolean;
+```
+
+Defined in: [main.ts:369](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L369)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
+---
+
+### isDefined()
+
+Copy of `isNotUndefined`
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
+```ts
+function isDefined<T>(value): value is Exclude<T, undefined>;
+```
+
+Defined in: [main.ts:165](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L165)
+
+**Type Parameters**
+
+| Type Parameter |
+| -------------- |
+| `T`            |
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, undefined>`
+
+**Call Signature**
+
+```ts
+function isDefined(value): boolean;
+```
+
+Defined in: [main.ts:170](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L170)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
 ---
 
 ### isInstanceOfUnknownClass()
-
-```ts
-function isInstanceOfUnknownClass(value): boolean;
-```
-
-Defined in: [main.ts:324](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L324)
 
 Checks if a given value is an instance of a non-standard (unknown) class.
 
@@ -124,19 +368,11 @@ This function determines whether the provided value is an object and has a proto
 that is neither `Object.prototype` (standard object) nor `null` (no prototype).
 It helps differentiate between instances of custom classes and plain objects.
 
-#### Parameters
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
+The value to check.
 
-#### Returns
-
-`boolean`
-
-`true` if the value is an instance of a non-standard class, otherwise `false`.
-
-#### Example
+**Example**
 
 ```ts
 class MyClass {}
@@ -146,154 +382,310 @@ console.log(isInstanceOfUnknownClass(Object.create(null))); // Output: false
 console.log(isInstanceOfUnknownClass([])); // Output: true
 ```
 
+**Call Signature**
+
+```ts
+function isInstanceOfUnknownClass(value): value is object;
+```
+
+Defined in: [main.ts:595](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L595)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is object`
+
+**Call Signature**
+
+```ts
+function isInstanceOfUnknownClass(value): boolean;
+```
+
+Defined in: [main.ts:600](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L600)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
 ---
 
 ### isNotBoolean()
 
+Checks if the given value is not a boolean.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNotBoolean(variable): boolean;
+function isNotBoolean<T>(value): value is Exclude<T, boolean>;
 ```
 
-Defined in: [main.ts:50](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L50)
+Defined in: [main.ts:105](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L105)
 
-Checks if the given variable is not a boolean.
+**Type Parameters**
 
-#### Parameters
+| Type Parameter |
+| -------------- |
+| `T`            |
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+**Parameters**
 
-#### Returns
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, boolean>`
+
+**Call Signature**
+
+```ts
+function isNotBoolean(value): boolean;
+```
+
+Defined in: [main.ts:110](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L110)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
 
 `boolean`
-
-True if the variable is not a boolean, false otherwise.
 
 ---
 
 ### isNotNumber()
 
+Checks if the given value is not a number.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNotNumber(variable): boolean;
+function isNotNumber<T>(value): value is Exclude<T, number>;
 ```
 
-Defined in: [main.ts:33](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L33)
+Defined in: [main.ts:65](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L65)
 
-Checks if the given variable is not a number.
+**Type Parameters**
 
-#### Parameters
+| Type Parameter |
+| -------------- |
+| `T`            |
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+**Parameters**
 
-#### Returns
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, number>`
+
+**Call Signature**
+
+```ts
+function isNotNumber(value): boolean;
+```
+
+Defined in: [main.ts:70](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L70)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
 
 `boolean`
-
-True if the variable is not a number, false otherwise.
 
 ---
 
 ### isNotString()
 
+Checks if the given value is not a string.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNotString(variable): boolean;
+function isNotString<T>(value): value is Exclude<T, string>;
 ```
 
-Defined in: [main.ts:16](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L16)
+Defined in: [main.ts:25](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L25)
 
-Checks if the given variable is not a string.
+**Type Parameters**
 
-#### Parameters
+| Type Parameter |
+| -------------- |
+| `T`            |
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+**Parameters**
 
-#### Returns
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, string>`
+
+**Call Signature**
+
+```ts
+function isNotString(value): boolean;
+```
+
+Defined in: [main.ts:30](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L30)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
 
 `boolean`
-
-True if the variable is not a string, false otherwise.
 
 ---
 
 ### isNotUndefined()
 
+Checks if the given value is not undefined.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNotUndefined(variable): boolean;
+function isNotUndefined<T>(value): value is Exclude<T, undefined>;
 ```
 
-Defined in: [main.ts:68](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L68)
+Defined in: [main.ts:145](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L145)
 
-Checks if the given variable is not undefined.
+**Type Parameters**
 
-#### Parameters
+| Type Parameter |
+| -------------- |
+| `T`            |
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+**Parameters**
 
-#### Returns
+| Parameter | Type |
+| --------- | ---- |
+| `value`   | `T`  |
+
+**Returns**
+
+`value is Exclude<T, undefined>`
+
+**Call Signature**
+
+```ts
+function isNotUndefined(value): boolean;
+```
+
+Defined in: [main.ts:150](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L150)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
 
 `boolean`
-
-True if the variable is not undefined, false otherwise.
 
 ---
 
 ### isNumber()
 
+Checks if the given value is a number.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isNumber(variable): boolean;
+function isNumber(value): value is number;
 ```
 
-Defined in: [main.ts:24](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L24)
+Defined in: [main.ts:45](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L45)
 
-Checks if the given variable is a number.
+**Parameters**
 
-#### Parameters
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+**Returns**
 
-#### Returns
+`value is number`
+
+**Call Signature**
+
+```ts
+function isNumber(value): boolean;
+```
+
+Defined in: [main.ts:50](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L50)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
 
 `boolean`
-
-True if the variable is a number, false otherwise.
 
 ---
 
 ### isObjectLoose()
-
-```ts
-function isObjectLoose(value): boolean;
-```
-
-Defined in: [main.ts:210](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L210)
 
 Checks if a given value is an object or a function.
 
 This function verifies whether the provided value is of type `'object'` or `'function'`
 while ensuring that `null` is excluded.
 
-#### Parameters
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
+The value to check.
 
-#### Returns
-
-`boolean`
-
-`true` if the value is an object or function, otherwise `false`.
-
-#### Example
+**Example**
 
 ```ts
 console.log(isObjectLoose({})); // Output: true
@@ -309,7 +701,7 @@ console.log(isObjectLoose(42)); // Output: false
 - ✅ Recognizes **functions** as objects (since functions are technically objects in JavaScript).
 - ❌ Does **not** differentiate between plain objects and special objects (like arrays, functions, DOM nodes, etc.).
 
-**Behavior**
+**Behaviour**
 
 - ✅ `isObjectLoose({})` → `true`
 - ✅ `isObjectLoose([])` → `true`
@@ -322,25 +714,56 @@ console.log(isObjectLoose(42)); // Output: false
 - Use `isObjectLoose` if you need to check if a value is an **object-like structure**, including functions.
 
 **Comparison**
-| Feature | Strict Check (`isObjectStrict`) | Loose Check (`isObjectLoose`) |
-|------------------------|----------------------|----------------------|
-| Recognizes plain objects | ✅ Yes | ✅ Yes |
-| Recognizes functions | ❌ No | ✅ Yes |
-| Recognizes arrays | ❌ No | ✅ Yes |
-| Recognizes `Object.create(null)` objects | ✅ Yes | ✅ Yes |
-| Recognizes class instances | ❌ No | ✅ Yes |
-| Recognizes DOM elements | ❌ No | ✅ Yes |
-| Complexity | 🔴 High | 🟢 Low |
+
+| Feature                                  | Strict Check (`isObjectStrict`) | Loose Check (`isObjectLoose`) |
+| ---------------------------------------- | ------------------------------- | ----------------------------- |
+| Recognizes plain objects                 | ✅ Yes                           | ✅ Yes                         |
+| Recognizes functions                     | ❌ No                            | ✅ Yes                         |
+| Recognizes arrays                        | ❌ No                            | ✅ Yes                         |
+| Recognizes `Object.create(null)` objects | ✅ Yes                           | ✅ Yes                         |
+| Recognizes class instances               | ❌ No                            | ✅ Yes                         |
+| Recognizes DOM elements                  | ❌ No                            | ✅ Yes                         |
+| Complexity                               | 🔴 High                          | 🟢 Low                         |
+
+**Call Signature**
+
+```ts
+function isObjectLoose(value): value is object;
+```
+
+Defined in: [main.ts:301](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L301)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is object`
+
+**Call Signature**
+
+```ts
+function isObjectLoose(value): boolean;
+```
+
+Defined in: [main.ts:306](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L306)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
 
 ---
 
 ### isObjectPlain()
-
-```ts
-function isObjectPlain(variable): boolean;
-```
-
-Defined in: [main.ts:104](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L104)
 
 Determines whether a value is a plain object (i.e., created via an object literal,
 `Object.create(null)`, or with `Object` as its prototype).
@@ -348,19 +771,11 @@ Determines whether a value is a plain object (i.e., created via an object litera
 This excludes arrays, functions, class instances, built-ins like `Date`/`Map`/`Set`,
 and other exotic objects.
 
-#### Parameters
+**Param**
 
-| Parameter  | Type      | Description        |
-| ---------- | --------- | ------------------ |
-| `variable` | `unknown` | The value to test. |
+The value to test.
 
-#### Returns
-
-`boolean`
-
-`true` if `variable` is a plain object, otherwise `false`.
-
-#### Example
+**Example**
 
 ```ts
 const a: unknown = { x: 1 };
@@ -383,18 +798,48 @@ if (isObjectPlain(value)) {
 
 #### See
 
-- https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/Object/toString
-- https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/Object/getPrototypeOf
+- <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/Object/toString>
+- <https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global\_Objects/Object/getPrototypeOf>
+
+**Call Signature**
+
+```ts
+function isObjectPlain(value): value is Record<string, unknown>;
+```
+
+Defined in: [main.ts:185](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L185)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is Record<string, unknown>`
+
+**Call Signature**
+
+```ts
+function isObjectPlain(value): boolean;
+```
+
+Defined in: [main.ts:190](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L190)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
 
 ---
 
 ### isObjectStrict()
-
-```ts
-function isObjectStrict(value): boolean;
-```
-
-Defined in: [main.ts:146](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L146)
 
 Checks if a given value is a plain object.
 
@@ -402,19 +847,11 @@ A plain object is an object created by the `{}` syntax, `Object.create(null)`,
 or using `new Object()`. This function ensures that the value is an object
 and does not have an unusual prototype chain.
 
-#### Parameters
+**Param**
 
-| Parameter | Type      | Description         |
-| --------- | --------- | ------------------- |
-| `value`   | `unknown` | The value to check. |
+The value to check.
 
-#### Returns
-
-`boolean`
-
-`true` if the value is a plain object, otherwise `false`.
-
-#### Example
+**Example**
 
 ```ts
 console.log(isObjectStrict({})); // Output: true
@@ -429,7 +866,7 @@ console.log(isObjectStrict(null)); // Output: false
 - ✅ Recognizes only **plain objects** (created via `{}`, `new Object()`, `Object.create(null)`, etc.).
 - ❌ Rejects **arrays**, **functions**, **DOM elements**, **class instances**, and **custom objects** with modified constructors.
 
-**Behavior**
+**Behaviour**
 
 - ✅ `isObjectStrict({})` → `true`
 - ❌ `isObjectStrict([])` → `false`
@@ -441,53 +878,133 @@ console.log(isObjectStrict(null)); // Output: false
 - Use `isObjectStrict` when you need a **strict check for plain objects**.
 - Use `isObjectLoose` if you need to check if a value is an **object-like structure**, including functions.
 
+**Call Signature**
+
+```ts
+function isObjectStrict(value): value is Record<string, unknown>;
+```
+
+Defined in: [main.ts:236](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L236)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`value is Record<string, unknown>`
+
+**Call Signature**
+
+```ts
+function isObjectStrict(value): boolean;
+```
+
+Defined in: [main.ts:243](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L243)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
+
+`boolean`
+
 ---
 
 ### isString()
 
+Checks if the given value is a string.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isString(variable): boolean;
+function isString(value): value is string;
 ```
 
-Defined in: [main.ts:7](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L7)
+Defined in: [main.ts:5](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L5)
 
-Checks if the given variable is a string.
+**Parameters**
 
-#### Parameters
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+**Returns**
 
-#### Returns
+`value is string`
+
+**Call Signature**
+
+```ts
+function isString(value): boolean;
+```
+
+Defined in: [main.ts:10](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L10)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
 
 `boolean`
-
-True if the variable is a string, false otherwise.
 
 ---
 
 ### isUndefined()
 
+Checks if the given value is undefined.
+
+**Param**
+
+The value to check.
+
+**Call Signature**
+
 ```ts
-function isUndefined(variable): boolean;
+function isUndefined(value): value is undefined;
 ```
 
-Defined in: [main.ts:59](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L59)
+Defined in: [main.ts:125](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L125)
 
-Checks if the given variable is undefined.
+**Parameters**
 
-#### Parameters
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
 
-| Parameter  | Type      | Description            |
-| ---------- | --------- | ---------------------- |
-| `variable` | `unknown` | The variable to check. |
+**Returns**
 
-#### Returns
+`value is undefined`
+
+**Call Signature**
+
+```ts
+function isUndefined(value): boolean;
+```
+
+Defined in: [main.ts:130](https://github.com/phun-ky/typeof/blob/main/src/main.ts#L130)
+
+**Parameters**
+
+| Parameter | Type      |
+| --------- | --------- |
+| `value`   | `unknown` |
+
+**Returns**
 
 `boolean`
-
-True if the variable is undefined, false otherwise.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "isNotBoolean",
     "isUndefined",
     "isNotUndefined",
+    "isDefined",
     "isObjectStrict",
     "isObjectLoose",
     "isClass",
     "isBuiltInConstructor",
+    "isBuiltInCallable",
     "isInstanceOfUnknownClass"
   ],
   "homepage": "https://phun-ky.net/projects/typeof",

--- a/src/__tests__/typeof.ts
+++ b/src/__tests__/typeof.ts
@@ -15,7 +15,8 @@ import {
   isClass,
   isBuiltInConstructor,
   isInstanceOfUnknownClass,
-  isObjectPlain
+  isObjectPlain,
+  isBuiltInCallable
 } from '../main';
 
 describe('isString', () => {
@@ -372,8 +373,6 @@ describe('isBuiltInConstructor', () => {
     assert.strictEqual(isBuiltInConstructor(Set), true);
     assert.strictEqual(isBuiltInConstructor(WeakSet), true);
     assert.strictEqual(isBuiltInConstructor(Promise), true);
-    assert.strictEqual(isBuiltInConstructor(BigInt), true);
-    assert.strictEqual(isBuiltInConstructor(Symbol), true);
   });
 
   it('returns false for custom classes', () => {
@@ -411,6 +410,96 @@ describe('isBuiltInConstructor', () => {
     assert.strictEqual(isBuiltInConstructor([]), false);
     assert.strictEqual(isBuiltInConstructor({}), false);
     assert.strictEqual(isBuiltInConstructor(new Date()), false);
+  });
+});
+
+
+describe('isBuiltInCallable', () => {
+  describe('returns true for built-in constructors', () => {
+    it('Object, Array, Function, String, Number, Boolean', () => {
+      assert.equal(isBuiltInCallable(Object), true);
+      assert.equal(isBuiltInCallable(Array), true);
+      assert.equal(isBuiltInCallable(Function), true);
+      assert.equal(isBuiltInCallable(String), true);
+      assert.equal(isBuiltInCallable(Number), true);
+      assert.equal(isBuiltInCallable(Boolean), true);
+    });
+
+    it('Date, RegExp, Error family', () => {
+      assert.equal(isBuiltInCallable(Date), true);
+      assert.equal(isBuiltInCallable(RegExp), true);
+      assert.equal(isBuiltInCallable(Error), true);
+      assert.equal(isBuiltInCallable(EvalError), true);
+      assert.equal(isBuiltInCallable(RangeError), true);
+      assert.equal(isBuiltInCallable(ReferenceError), true);
+      assert.equal(isBuiltInCallable(SyntaxError), true);
+      assert.equal(isBuiltInCallable(TypeError), true);
+      assert.equal(isBuiltInCallable(URIError), true);
+    });
+
+    it('Collections: Map, WeakMap, Set, WeakSet, Promise', () => {
+      assert.equal(isBuiltInCallable(Map), true);
+      assert.equal(isBuiltInCallable(WeakMap), true);
+      assert.equal(isBuiltInCallable(Set), true);
+      assert.equal(isBuiltInCallable(WeakSet), true);
+      assert.equal(isBuiltInCallable(Promise), true);
+    });
+  });
+
+  describe('returns true for callable non-constructable built-ins', () => {
+    it('BigInt and Symbol', () => {
+      assert.equal(isBuiltInCallable(BigInt), true);
+      assert.equal(isBuiltInCallable(Symbol), true);
+    });
+  });
+
+  describe('returns false for userland functions/classes', () => {
+    it('class declarations and regular/arrow functions', () => {
+      class MyClass {}
+      function fn() {}
+      const arrow = () => {};
+      async function afn() {}
+      function* gfn() {}
+
+      assert.equal(isBuiltInCallable(MyClass), false);
+      assert.equal(isBuiltInCallable(fn), false);
+      assert.equal(isBuiltInCallable(arrow), false);
+      assert.equal(isBuiltInCallable(afn), false);
+      assert.equal(isBuiltInCallable(gfn), false);
+    });
+  });
+
+  describe('returns false for other built-in functions not in the set', () => {
+    it('Math.max, Date.now, Map.prototype.get', () => {
+      assert.equal(isBuiltInCallable(Math.max), false);
+      assert.equal(isBuiltInCallable(Date.now), false);
+      assert.equal(isBuiltInCallable(Map.prototype.get), false);
+    });
+  });
+
+  describe('returns false for wrapped/bound/proxied callables', () => {
+    it('bound Array and proxied Array', () => {
+      const boundArray = Array.bind(null);
+      const proxiedArray = new Proxy(Array, {});
+      assert.equal(isBuiltInCallable(boundArray), false);
+      assert.equal(isBuiltInCallable(proxiedArray), false);
+    });
+  });
+
+  describe('returns false for non-function values', () => {
+    it('primitives and objects', () => {
+      assert.equal(isBuiltInCallable(123 as unknown), false);
+      assert.equal(isBuiltInCallable('abc' as unknown), false);
+      assert.equal(isBuiltInCallable(true as unknown), false);
+      assert.equal(isBuiltInCallable(null as unknown), false);
+      assert.equal(isBuiltInCallable(undefined as unknown), false);
+      assert.equal(isBuiltInCallable(Symbol('x') as unknown), false);
+      assert.equal(isBuiltInCallable(10n as unknown), false);
+      assert.equal(isBuiltInCallable({} as unknown), false);
+      assert.equal(isBuiltInCallable([] as unknown), false);
+      assert.equal(isBuiltInCallable(new Date() as unknown), false);
+      assert.equal(isBuiltInCallable(new Map() as unknown), false);
+    });
   });
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,72 +1,195 @@
+/* eslint-disable import/no-unused-modules */
 /**
- * Checks if the given variable is a string.
- *
- * @param {unknown} variable - The variable to check.
- * @returns {boolean} True if the variable is a string, false otherwise.
+ * @overload
  */
-export const isString = (variable: unknown): boolean =>
-  typeof variable === 'string';
+export function isString(value: unknown): value is string;
 
 /**
- * Checks if the given variable is not a string.
- *
- * @param {unknown} variable - The variable to check.
- * @returns {boolean} True if the variable is not a string, false otherwise.
+ * @overload
  */
-export const isNotString = (variable: unknown): boolean => !isString(variable);
+export function isString(value: unknown): boolean;
 
 /**
- * Checks if the given variable is a number.
+ * Checks if the given value is a string.
  *
- * @param {unknown} variable - The variable to check.
- * @returns {boolean} True if the variable is a number, false otherwise.
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is a string, false otherwise.
  */
-export const isNumber = (variable: unknown): boolean =>
-  typeof variable === 'number';
+export function isString(value: unknown): boolean {
+  return typeof value === 'string';
+}
 
 /**
- * Checks if the given variable is not a number.
- *
- * @param {unknown} variable - The variable to check.
- * @returns {boolean} True if the variable is not a number, false otherwise.
+ * @overload
  */
-export const isNotNumber = (variable: unknown): boolean => !isNumber(variable);
+export function isNotString<T>(value: T): value is Exclude<T, string>;
 
 /**
- * Checks if the given variable is a boolean.
- *
- * @param {unknown} variable - The variable to check.
- * @returns {boolean} True if the variable is a boolean, false otherwise.
+ * @overload
  */
-export const isBoolean = (variable: unknown): boolean =>
-  typeof variable === 'boolean';
+export function isNotString(value: unknown): boolean;
 
 /**
- * Checks if the given variable is not a boolean.
+ * Checks if the given value is not a string.
  *
- * @param {unknown} variable - The variable to check.
- * @returns {boolean} True if the variable is not a boolean, false otherwise.
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is not a string, false otherwise.
  */
-export const isNotBoolean = (variable: unknown): boolean =>
-  !isBoolean(variable);
+export function isNotString(value: unknown): boolean {
+  return !isString(value);
+}
 
 /**
- * Checks if the given variable is undefined.
- *
- * @param {unknown} variable - The variable to check.
- * @returns {boolean} True if the variable is undefined, false otherwise.
+ * @overload
  */
-export const isUndefined = (variable: unknown): boolean =>
-  typeof variable === 'undefined';
+export function isNumber(value: unknown): value is number;
 
 /**
- * Checks if the given variable is not undefined.
- *
- * @param {unknown} variable - The variable to check.
- * @returns {boolean} True if the variable is not undefined, false otherwise.
+ * @overload
  */
-export const isNotUndefined = (variable: unknown): boolean =>
-  !isUndefined(variable);
+export function isNumber(value: unknown): boolean;
+
+/**
+ * Checks if the given value is a number.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is a number, false otherwise.
+ */
+export function isNumber(value: unknown): boolean {
+  return typeof value === 'number';
+}
+
+/**
+ * @overload
+ */
+export function isNotNumber<T>(value: T): value is Exclude<T, number>;
+
+/**
+ * @overload
+ */
+export function isNotNumber(value: unknown): boolean;
+
+/**
+ * Checks if the given value is not a number.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is not a number, false otherwise.
+ */
+export function isNotNumber(value: unknown): boolean {
+  return !isNumber(value);
+}
+
+/**
+ * @overload
+ */
+export function isBoolean(value: unknown): value is boolean;
+
+/**
+ * @overload
+ */
+export function isBoolean(value: unknown): boolean;
+
+/**
+ * Checks if the given value is a boolean.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is a boolean, false otherwise.
+ */
+export function isBoolean(value: unknown): boolean {
+  return typeof value === 'boolean';
+}
+
+/**
+ * @overload
+ */
+export function isNotBoolean<T>(value: T): value is Exclude<T, boolean>;
+
+/**
+ * @overload
+ */
+export function isNotBoolean(value: unknown): boolean;
+
+/**
+ * Checks if the given value is not a boolean.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is not a boolean, false otherwise.
+ */
+export function isNotBoolean(value: unknown): boolean {
+  return !isBoolean(value);
+}
+
+/**
+ * @overload
+ */
+export function isUndefined(value: unknown): value is undefined;
+
+/**
+ * @overload
+ */
+export function isUndefined(value: unknown): boolean;
+
+/**
+ * Checks if the given value is undefined.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is undefined, false otherwise.
+ */
+export function isUndefined(value: unknown): boolean {
+  return typeof value === 'undefined';
+}
+
+/**
+ * @overload
+ */
+export function isNotUndefined<T>(value: T): value is Exclude<T, undefined>;
+
+/**
+ * @overload
+ */
+export function isNotUndefined(value: unknown): boolean;
+
+/**
+ * Checks if the given value is not undefined.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is not undefined, false otherwise.
+ */
+export function isNotUndefined(value: unknown): boolean {
+  return !isUndefined(value);
+}
+
+/* node:coverage disable */
+/**
+ * @overload
+ */
+export function isDefined<T>(value: T): value is Exclude<T, undefined>;
+
+/**
+ * @overload
+ */
+export function isDefined(value: unknown): boolean;
+
+/**
+ * Copy of `isNotUndefined`
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} True if the value is defined, false otherwise.
+ */
+export function isDefined(value: unknown): boolean {
+  return !isUndefined(value);
+}
+/* node:coverage enable */
+
+/**
+ * @overload
+ */
+export function isObjectPlain(value: unknown): value is Record<string, unknown>;
+
+/**
+ * @overload
+ */
+export function isObjectPlain(value: unknown): boolean;
 
 /**
  * Determines whether a value is a plain object (i.e., created via an object literal,
@@ -75,8 +198,8 @@ export const isNotUndefined = (variable: unknown): boolean =>
  * This excludes arrays, functions, class instances, built-ins like `Date`/`Map`/`Set`,
  * and other exotic objects.
  *
- * @param {unknown} variable - The value to test.
- * @returns {boolean} `true` if `variable` is a plain object, otherwise `false`.
+ * @param {unknown} value - The value to test.
+ * @returns {boolean} `true` if `value` is a plain object, otherwise `false`.
  *
  * @example
  * ```ts
@@ -101,14 +224,25 @@ export const isNotUndefined = (variable: unknown): boolean =>
  * @see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
  * @see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
  */
-export const isObjectPlain = (variable: unknown): boolean => {
-  if (Object.prototype.toString.call(variable) !== '[object Object]')
-    return false;
+export function isObjectPlain(value: unknown): boolean {
+  if (Object.prototype.toString.call(value) !== '[object Object]') return false;
 
-  const proto = Object.getPrototypeOf(variable);
+  const proto = Object.getPrototypeOf(value);
 
   return proto === Object.prototype || proto === null;
-};
+}
+
+/**
+ * @overload
+ */
+export function isObjectStrict(
+  value: unknown
+): value is Record<string, unknown>;
+
+/**
+ * @overload
+ */
+export function isObjectStrict(value: unknown): boolean;
 
 /**
  * Checks if a given value is a plain object.
@@ -143,7 +277,7 @@ export const isObjectPlain = (variable: unknown): boolean => {
  * - Use `isObjectStrict` when you need a **strict check for plain objects**.
  * - Use `isObjectLoose` if you need to check if a value is an **object-like structure**, including functions.
  */
-export const isObjectStrict = (value: unknown): boolean => {
+export function isObjectStrict(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) return false;
 
   if (Object.prototype.toString.call(value) !== '[object Object]') return false;
@@ -161,7 +295,17 @@ export const isObjectStrict = (value: unknown): boolean => {
     Ctor instanceof Ctor &&
     Function.prototype.call(Ctor) === Function.prototype.call(value)
   );
-};
+}
+
+/**
+ * @overload
+ */
+export function isObjectLoose(value: unknown): value is object;
+
+/**
+ * @overload
+ */
+export function isObjectLoose(value: unknown): boolean;
 
 /**
  * Checks if a given value is an object or a function.
@@ -207,11 +351,24 @@ export const isObjectStrict = (value: unknown): boolean => {
  * | Recognizes DOM elements | ❌ No | ✅ Yes |
  * | Complexity             | 🔴 High | 🟢 Low |
  */
-export const isObjectLoose = (value: unknown): boolean => {
+export function isObjectLoose(value: unknown): boolean {
   const type = typeof value;
 
   return value !== null && (type === 'object' || type === 'function');
-};
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ClassCtor<T = any> = new (...args: any[]) => T;
+
+/**
+ * @overload
+ */
+export function isClass(value: unknown): value is ClassCtor;
+
+/**
+ * @overload
+ */
+export function isClass(value: unknown): boolean;
 
 /**
  * Checks if a given value is a class constructor.
@@ -237,7 +394,7 @@ export const isObjectLoose = (value: unknown): boolean => {
  * console.log(isClass(null)); // Output: false
  * ```
  */
-export const isClass = (value: unknown): boolean => {
+export function isClass(value: unknown): boolean {
   if (typeof value !== 'function') return false;
 
   if (isBuiltInConstructor(value)) return false;
@@ -250,7 +407,45 @@ export const isClass = (value: unknown): boolean => {
   } catch {
     return false;
   }
-};
+}
+
+/**
+ * A union of standard JavaScript **constructable** built-ins
+ * (e.g., `Object`, `Array`, `Date`, `Map`, etc.).
+ */
+export type BuiltInConstructor =
+  | ObjectConstructor
+  | ArrayConstructor
+  | FunctionConstructor
+  | StringConstructor
+  | NumberConstructor
+  | BooleanConstructor
+  | DateConstructor
+  | RegExpConstructor
+  | ErrorConstructor
+  | EvalErrorConstructor
+  | RangeErrorConstructor
+  | ReferenceErrorConstructor
+  | SyntaxErrorConstructor
+  | TypeErrorConstructor
+  | URIErrorConstructor
+  | MapConstructor
+  | WeakMapConstructor
+  | SetConstructor
+  | WeakSetConstructor
+  | PromiseConstructor;
+
+/**
+ * @overload
+ */
+export function isBuiltInConstructor(
+  value: unknown
+): value is BuiltInConstructor;
+
+/**
+ * @overload
+ */
+export function isBuiltInConstructor(value: unknown): boolean;
 
 /**
  * Checks if a given value is a built-in JavaScript constructor.
@@ -270,7 +465,7 @@ export const isClass = (value: unknown): boolean => {
  * console.log(isBuiltInConstructor(123)); // Output: false
  * ```
  */
-export const isBuiltInConstructor = (value: unknown): boolean => {
+export function isBuiltInConstructor(value: unknown): boolean {
   if (typeof value !== 'function') return false;
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -294,13 +489,117 @@ export const isBuiltInConstructor = (value: unknown): boolean => {
     WeakMap,
     Set,
     WeakSet,
-    Promise,
-    BigInt,
-    Symbol
+    Promise
   ];
 
-  return builtins.includes(value);
-};
+  return builtins.includes(value as BuiltInConstructor);
+}
+
+/**
+ * Built-in globals that are **callable**:
+ * - All standard constructors (above)
+ * - Plus callable, **non-constructable** built-ins: `BigInt` and `Symbol`
+ */
+export type BuiltInCallable =
+  | BuiltInConstructor
+  | typeof BigInt
+  | typeof Symbol;
+
+/**
+ * Canonical set of built-in callables.
+ * Note: identity is **realm-specific** (different iframes/VMs have different
+ * constructor identities), so values from another realm won't match here.
+ */
+const BUILTIN_CALLABLES: ReadonlySet<BuiltInCallable> = new Set([
+  Object,
+  Array,
+  Function,
+  String,
+  Number,
+  Boolean,
+  Date,
+  RegExp,
+  Error,
+  EvalError,
+  RangeError,
+  ReferenceError,
+  SyntaxError,
+  TypeError,
+  URIError,
+  Map,
+  WeakMap,
+  Set,
+  WeakSet,
+  Promise,
+  BigInt,
+  Symbol
+]);
+
+/**
+ * @overload
+ */
+export function isBuiltInCallable(value: unknown): value is BuiltInCallable;
+
+/**
+ * @overload
+ */
+export function isBuiltInCallable(value: unknown): boolean;
+
+/**
+ * Checks if a given value is a **built-in JavaScript callable**.
+ *
+ * A built-in callable is either:
+ * - a standard **constructor** (e.g., `Object`, `Array`, `Date`, `Map`), or
+ * - a callable **non-constructable** built-in (`BigInt`, `Symbol`).
+ *
+ * This function first verifies the value is a function, then tests identity
+ * against a curated set of built-ins.
+ *
+ * Overloads:
+ * - **Predicate:** narrows the value to `BuiltInCallable` on success.
+ * - **Boolean:** usable in contexts that require a plain `(v) => boolean`.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} `true` if the value is a built-in callable, otherwise `false`.
+ *
+ * @example
+ * ```ts
+ * isBuiltInCallable(Object);       // true
+ * isBuiltInCallable(Array);        // true
+ * isBuiltInCallable(BigInt);       // true (callable but not a constructor)
+ * isBuiltInCallable(Symbol);       // true (callable but not a constructor)
+ * isBuiltInCallable(class X {});   // false
+ * isBuiltInCallable(() => {});     // false
+ * isBuiltInCallable(123);          // false
+ *
+ * // Type narrowing:
+ * declare const fn: unknown;
+ * if (isBuiltInCallable(fn)) {
+ *   // fn is now typed as BuiltInCallable
+ *   console.log(fn.name);
+ * }
+ * ```
+ *
+ * @see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects
+ * @see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+ * @see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+ */
+export function isBuiltInCallable(value: unknown): boolean {
+  return (
+    typeof value === 'function' &&
+    BUILTIN_CALLABLES.has(value as BuiltInCallable)
+  );
+}
+
+/**
+ * @overload
+ */
+export function isInstanceOfUnknownClass(value: unknown): value is object;
+
+/**
+ * @overload
+ */
+export function isInstanceOfUnknownClass(value: unknown): boolean;
 
 /**
  * Checks if a given value is an instance of a non-standard (unknown) class.
@@ -321,8 +620,11 @@ export const isBuiltInConstructor = (value: unknown): boolean => {
  * console.log(isInstanceOfUnknownClass([])); // Output: true
  * ```
  */
-export const isInstanceOfUnknownClass = (value: unknown): boolean =>
-  typeof value === 'object' &&
-  value !== null &&
-  Object.getPrototypeOf(value) !== Object.prototype &&
-  Object.getPrototypeOf(value) !== null;
+export function isInstanceOfUnknownClass(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.getPrototypeOf(value) !== Object.prototype &&
+    Object.getPrototypeOf(value) !== null
+  );
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -11,6 +11,7 @@
   "tsconfig": "tsconfig.json",
   "outputFileStrategy": "modules",
   "interfacePropertiesFormat": "table",
+  "excludeInternal": true,
   "classPropertiesFormat": "table",
   "enumMembersFormat": "table",
   "typeDeclarationFormat": "htmlTable",


### PR DESCRIPTION
- Convert `export const` arrow helpers to `export function` declarations to enable overloads and improve inference/hoisting:
- Add type-guard overloads (with boolean fallbacks) for the functions to support control-flow narrowing and HOF usage
- `isBuiltInCallable` (constructors + `BigInt`/`Symbol`) with narrowing to `BuiltInCallable`
- `isBuiltInConstructor` now excludes non-constructable globals (`BigInt`, `Symbol`) and narrows to `BuiltInConstructor`
- Hoist built-in callable/constructor collections to module scope
- `isDefined` is now added as a clone of `isNotUndefined`
- Add unit tests for `isBuiltInCallable`, including identity edge cases (bound/proxied) and negatives
- Expand JSDoc with examples and MDN references

Migration: if you previously relied on `isBuiltInConstructor(BigInt|Symbol) === true`, replace with `isBuiltInCallable(BigInt|Symbol)`.

BREAKING CHANGE: 🧨 You can no longer use `isBuiltInConstructor` to check for `BigInt` or `Symbol`, use `isBuiltInCallable(BigInt) || isBuiltInCallable(Symbol)` instead.